### PR TITLE
Update package namespace in FIELDBUS conversion functions

### DIFF
--- a/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis">
-	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -31,26 +31,26 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier" />
-			<VarDeclaration Name="MI" Type="REAL" Comment="MID Setting can e.g. be 0.5 meaning 50%"  InitialValue="0.5"/>
-			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MID can be e.g. 0.1 meaning 10%"  InitialValue="0.1"/>
-			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis can be 0.1 meaning 10%"  InitialValue="0.1"/>
-			<VarDeclaration Name="INPUT" Type="REAL" Comment="Value" />
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier"/>
+			<VarDeclaration Name="MI" Type="REAL" Comment="MID Setting can e.g. be 0.5 meaning 50%" InitialValue="0.5"/>
+			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MID can be e.g. 0.1 meaning 10%" InitialValue="0.1"/>
+			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis can be 0.1 meaning 10%" InitialValue="0.1"/>
+			<VarDeclaration Name="INPUT" Type="REAL" Comment="Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
-			<VarDeclaration Name="DO_UP" Type="BOOL" Comment=" UP" />
-			<VarDeclaration Name="DO_DOWN" Type="BOOL" Comment="DOWN" />
+			<VarDeclaration Name="DO_UP" Type="BOOL" Comment=" UP"/>
+			<VarDeclaration Name="DO_DOWN" Type="BOOL" Comment="DOWN"/>
 		</OutputVars>
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State"  x="840" y="2460">
+			<ECState Name="START" Comment="Initial State" x="840" y="2460">
 			</ECState>
-			<ECState Name="Init" Comment="Initialization"  x="1600" y="2000">
+			<ECState Name="Init" Comment="Initialization" x="1600" y="2000">
 				<ECAction Algorithm="initialize" Output="INITO"/>
 			</ECState>
-			<ECState Name="UP" Comment="Normal execution"  x="6666.67" y="1066.67">
+			<ECState Name="UP" Comment="Normal execution" x="6666.67" y="1066.67">
 				<ECAction Algorithm="alUp" Output="CNF"/>
 			</ECState>
 			<ECState Name="Neutral" x="2266.67" y="2480">

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF">
-	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
+<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF">
+	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH     &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-01" Remarks="changed package">
 	</VersionInfo>
@@ -33,7 +33,7 @@
 	<FunctionBody>
 		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
-(* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0 *)
+(* Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF *)
 FUNCTION FIELDBUS_PERCENT_TO_WORD : WORD
 VAR_INPUT
 	RI : REAL; // Input Value

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0">
+<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-01" Remarks="changed package">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-09-19" Remarks="Update to a more Function like Interface">
@@ -22,14 +24,14 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="RI" Type="REAL" Comment="Input Value" />
+			<VarDeclaration Name="RI" Type="REAL" Comment="Input Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="" Type="WORD"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0 *)
 FUNCTION FIELDBUS_PERCENT_TO_WORD : WORD

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0">
+<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0)">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-01" Remarks="changed package">
@@ -35,7 +35,7 @@
 	<FunctionBody>
 		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
-(* Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF *)
+(* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) *)
 FUNCTION FIELDBUS_WORD_TO_PERCENT : REAL
 VAR_INPUT
 	WI : WORD; // Input Value

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF">
+<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-01" Remarks="changed package">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-09-19" Remarks="Update to a more Function like Interface">
@@ -23,15 +25,15 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="WI" Type="WORD" Comment="Input Value" />
+			<VarDeclaration Name="WI" Type="WORD" Comment="Input Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="" Type="REAL"/>
-			<VarDeclaration Name="WO" Type="WORD" Comment="Input Value mirror if Signal Valid." />
+			<VarDeclaration Name="WO" Type="WORD" Comment="Input Value mirror if Signal Valid."/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF *)
 FUNCTION FIELDBUS_WORD_TO_PERCENT : REAL

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/RampLimitFS.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/RampLimitFS.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="RampLimitFS" Comment="Setpoint Ramp: Step up and down Values with Fast and Slow mode">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;Setpoint Ramp: Step up and down Values, like well-known for the cruise control in your Car. Long press increase or decrease by 10, short press increase or decrease at 1. &#10;&#10;this FB adds Maximum and Minimum Value and also Inputs to set them. &#10;For some Applications it is neccessary to store the setpoint in Non-Volatile Storage, e.g. with a ini File, for this we have here a LOAD event input which loads value from the PV input">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH    &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;Setpoint Ramp: Step up and down Values, like well-known for the cruise control in your Car. Long press increase or decrease by 10, short press increase or decrease at 1. &#10;&#10;this FB adds Maximum and Minimum Value and also Inputs to set them. &#10;For some Applications it is neccessary to store the setpoint in Non-Volatile Storage, e.g. with a ini File, for this we have here a LOAD event input which loads value from the PV input">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -51,12 +51,33 @@
 		</OutputVars>
 	</InterfaceList>
 	<SimpleFB>
-		<Algorithm Name="ZERO" Comment="">
+		<ECState Name="ZERO">
+			<ECAction Algorithm="ZERO" Output="CNF"/>
+		</ECState>
+		<ECState Name="UP_SLOW">
+			<ECAction Algorithm="UP_SLOW" Output="CNF"/>
+		</ECState>
+		<ECState Name="UP_FAST">
+			<ECAction Algorithm="UP_FAST" Output="CNF"/>
+		</ECState>
+		<ECState Name="DOWN_SLOW">
+			<ECAction Algorithm="DOWN_SLOW" Output="CNF"/>
+		</ECState>
+		<ECState Name="DOWN_FAST">
+			<ECAction Algorithm="DOWN_FAST" Output="CNF"/>
+		</ECState>
+		<ECState Name="FULL">
+			<ECAction Algorithm="FULL" Output="CNF"/>
+		</ECState>
+		<ECState Name="LOAD">
+			<ECAction Algorithm="LOAD" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="ZERO">
 			<ST><![CDATA[ALGORITHM ZERO
 OUT := VAL_ZERO;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="UP_SLOW" Comment="">
+		<Algorithm Name="UP_SLOW">
 			<ST><![CDATA[
 
 ALGORITHM UP_SLOW
@@ -66,7 +87,7 @@ IF GT(OUT, VAL_FULL) THEN
 END_IF;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="UP_FAST" Comment="">
+		<Algorithm Name="UP_FAST">
 			<ST><![CDATA[
 
 ALGORITHM UP_FAST
@@ -76,7 +97,7 @@ IF GT(OUT, VAL_FULL) THEN
 END_IF;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="DOWN_SLOW" Comment="">
+		<Algorithm Name="DOWN_SLOW">
 			<ST><![CDATA[
 
 ALGORITHM DOWN_SLOW
@@ -86,7 +107,7 @@ IF LT(OUT, VAL_ZERO) THEN
 END_IF;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="DOWN_FAST" Comment="">
+		<Algorithm Name="DOWN_FAST">
 			<ST><![CDATA[
 
 ALGORITHM DOWN_FAST
@@ -96,14 +117,14 @@ IF LT(OUT, VAL_ZERO) THEN
 END_IF;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="FULL" Comment="">
+		<Algorithm Name="FULL">
 			<ST><![CDATA[
 
 ALGORITHM FULL
 OUT := VAL_FULL;
 END_ALGORITHM]]></ST>
 		</Algorithm>
-		<Algorithm Name="LOAD" Comment="">
+		<Algorithm Name="LOAD">
 			<ST><![CDATA[
 
 ALGORITHM LOAD

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Function Name="SCALE" Comment="Scaling Function Block">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;was inspired by this Video: &#10;EP2 - CODESYS: Create Scaling Function Block&#10;https://www.youtube.com/watch?v=Ir6QAxxDarI">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;was inspired by this Video: &#10;EP2 - CODESYS: Create Scaling Function Block&#10;https://www.youtube.com/watch?v=Ir6QAxxDarI">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -10,7 +10,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="">
+			<Event Name="REQ" Type="Event">
 				<With Var="IN"/>
 				<With Var="MAX_IN"/>
 				<With Var="MIN_IN"/>
@@ -19,7 +19,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
@@ -27,24 +27,24 @@
 			<VarDeclaration Name="IN" Type="REAL" Comment="Input to be Scaled"/>
 			<VarDeclaration Name="MAX_IN" Type="REAL" Comment="Maximum Input"/>
 			<VarDeclaration Name="MIN_IN" Type="REAL" Comment="Minimum Input"/>
-			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Ouput"/>
+			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Output"/>
 			<VarDeclaration Name="MIN_OUT" Type="REAL" Comment="Minimum Output"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="REAL" Comment=""/>
+			<VarDeclaration Name="" Type="REAL"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Scaling Function Block *)
 FUNCTION SCALE : REAL
 VAR_INPUT
-	IN : REAL;    // Input to be Scaled
-	MAX_IN : REAL;    // Maximum Input
-	MIN_IN : REAL;    // Minimum Input
-	MAX_OUT : REAL;    // Maximum Ouput
-	MIN_OUT : REAL;    // Minimum Output
+	IN : REAL; // Input to be Scaled
+	MAX_IN : REAL; // Maximum Input
+	MIN_IN : REAL; // Minimum Input
+	MAX_OUT : REAL; // Maximum Output
+	MIN_OUT : REAL; // Minimum Output
 END_VAR
 
 SCALE := (IN - MIN_IN) * (MAX_OUT - MIN_OUT) / (MAX_IN - MIN_IN) + MIN_OUT;

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Function Name="SCALE_LIM" Comment="Scaling Function Block with limits">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -10,7 +10,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="">
+			<Event Name="REQ" Type="Event">
 				<With Var="IN"/>
 				<With Var="MAX_IN"/>
 				<With Var="MIN_IN"/>
@@ -23,7 +23,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
@@ -31,37 +31,37 @@
 			<VarDeclaration Name="IN" Type="REAL" Comment="Input to be Scaled"/>
 			<VarDeclaration Name="MAX_IN" Type="REAL" Comment="Maximum Input"/>
 			<VarDeclaration Name="MIN_IN" Type="REAL" Comment="Minimum Input"/>
-			<VarDeclaration Name="MAX_IN_LIM" Type="REAL" Comment="Maximum Input Limit, if IN is bigger, Output is MAX2_ESC"/>
-			<VarDeclaration Name="MIN_IN_LIM" Type="REAL" Comment="Minimum Input Limit, if IN is smaller, Output is MIN2_ESC"/>
-			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Ouput"/>
+			<VarDeclaration Name="MAX_IN_LIM" Type="REAL" Comment="Maximum Input Limit; if IN is greater than MAX_IN_LIM, the output is MAX_OUT_FIX"/>
+			<VarDeclaration Name="MIN_IN_LIM" Type="REAL" Comment="Minimum Input Limit; if IN is less than MIN_IN_LIM, the output is MIN_OUT_FIX"/>
+			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Output"/>
 			<VarDeclaration Name="MIN_OUT" Type="REAL" Comment="Minimum Output"/>
-			<VarDeclaration Name="MAX_OUT_FIX" Type="REAL" Comment="Maximum Ouput Fix Value, ist set if IN is bigger than MAX_IN_LIM"/>
-			<VarDeclaration Name="MIN_OUT_FIX" Type="REAL" Comment="Minimum Output Fix Value, ist set if IN is smaller than MIN_IN_LIM"/>
+			<VarDeclaration Name="MAX_OUT_FIX" Type="REAL" Comment="Maximum Output Fix Value; is set if IN is greater than MAX_IN_LIM"/>
+			<VarDeclaration Name="MIN_OUT_FIX" Type="REAL" Comment="Minimum Output Fix Value; is set if IN is less than MIN_IN_LIM"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="REAL" Comment=""/>
+			<VarDeclaration Name="" Type="REAL"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Scaling Function Block with limits *)
 FUNCTION SCALE_LIM : REAL
 VAR_INPUT
-	IN : REAL;    // Input to be Scaled
-	MAX_IN : REAL;    // Maximum Input
-	MIN_IN : REAL;    // Minimum Input
-	MAX_IN_LIM : REAL;    // Maximum Input Limit, if IN is bigger, Output is MAX2_ESC
-	MIN_IN_LIM : REAL;    // Minimum Input Limit, if IN is smaller, Output is MIN2_ESC
-	MAX_OUT : REAL;    // Maximum Ouput
-	MIN_OUT : REAL;    // Minimum Output
-	MAX_OUT_FIX : REAL;    // Maximum Ouput Fix Value, ist set if IN is bigger than MAX_IN_LIM
-	MIN_OUT_FIX : REAL;    // Minimum Output Fix Value, ist set if IN is smaller than MIN_IN_LIM
+	IN : REAL; // Input to be Scaled
+	MAX_IN : REAL; // Maximum Input
+	MIN_IN : REAL; // Minimum Input
+	MAX_IN_LIM : REAL; // Maximum Input Limit; if IN is greater than MAX_IN_LIM, the output is MAX_OUT_FIX
+	MIN_IN_LIM : REAL; // Minimum Input Limit; if IN is less than MIN_IN_LIM, the output is MIN_OUT_FIX
+	MAX_OUT : REAL; // Maximum Output
+	MIN_OUT : REAL; // Minimum Output
+	MAX_OUT_FIX : REAL; // Maximum Output Fix Value; is set if IN is greater than MAX_IN_LIM
+	MIN_OUT_FIX : REAL; // Minimum Output Fix Value; is set if IN is less than MIN_IN_LIM
 END_VAR
 
 IF (IN < MIN_IN_LIM) THEN
 	SCALE_LIM := MIN_OUT_FIX;
-ELSIF (IN> MAX_IN_LIM) THEN
+ELSIF (IN > MAX_IN_LIM) THEN
 	SCALE_LIM := MAX_OUT_FIX;
 ELSE
 	SCALE_LIM := (IN - MIN_IN) * (MAX_OUT - MIN_OUT) / (MAX_IN - MIN_IN) + MIN_OUT;

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/distance/RangeBasedPulse.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/distance/RangeBasedPulse.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="RangeBasedPulse" Comment="Distance based Impulse Generator">
-	<Identification Standard="61499-1" Description="Copyright (c) 2025 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;Distance based Impulse Generator&#10;&#10;START with a HIGH Pulse. ">
+	<Identification Standard="61499-1" Description="Copyright (c) 2025 HR Agrartechnik GmbH&#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;Distance based Impulse Generator&#10;&#10;START with a HIGH Pulse. ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -25,13 +25,13 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="DIST_IN" Type="UDINT" Comment="Travelled Distance" />
-			<VarDeclaration Name="DIST_OFF" Type="UDINT" Comment="Distance Offset" />
-			<VarDeclaration Name="DIST_HIGH" Type="UDINT" Comment="Distance for Output HIGH" />
-			<VarDeclaration Name="DIST_LOW" Type="UDINT" Comment="Distance for Output LOW" />
+			<VarDeclaration Name="DIST_IN" Type="UDINT" Comment="Travelled Distance"/>
+			<VarDeclaration Name="DIST_OFF" Type="UDINT" Comment="Distance Offset"/>
+			<VarDeclaration Name="DIST_HIGH" Type="UDINT" Comment="Distance for Output HIGH"/>
+			<VarDeclaration Name="DIST_LOW" Type="UDINT" Comment="Distance for Output LOW"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="Q" Type="BOOL" Comment="Output" />
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
 		</OutputVars>
 	</InterfaceList>
 	<SimpleFB>

--- a/data/typelibrary/utils-3.0.0/typelib/timing/F_NOW.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/timing/F_NOW.fct
@@ -23,7 +23,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE utils::timing;
+		<ST><![CDATA[PACKAGE eclipse4diac::utils::timing;
 
 (* returns current local date and time *)
 FUNCTION F_NOW : DATE_AND_TIME

--- a/data/typelibrary/utils-3.0.0/typelib/timing/F_NOW_MONOTONIC.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/timing/F_NOW_MONOTONIC.fct
@@ -23,7 +23,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE utils::timing;
+		<ST><![CDATA[PACKAGE eclipse4diac::utils::timing;
 
 (* returns current monotonic clock value *)
 FUNCTION F_NOW_MONOTONIC : TIME

--- a/data/typelibrary/utils-3.0.0/typelib/timing/TIMESTAMP_NS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/timing/TIMESTAMP_NS.fct
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="TIMESTAMP_NS" Comment="creates default a Unix-Epoch-Timestamp in nanoseconds use other start dates for other timestamp types">
+<Function Name="TIMESTAMP_NS" Comment="Creates by default a Unix-Epoch-Timestamp in nanoseconds. Use other start dates for other&#10;timestamp types.">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 Monika Wenger&#10;  &#10;This program and the accompanying materials are made &#10;available under the terms of the Eclipse Public License 2.0 &#10;which is available at https://www.eclipse.org/legal/epl-2.0/ &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,12 +10,12 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="request to create a timestamp">
+			<Event Name="REQ" Type="Event">
 				<With Var="startDate"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="confirms the creation of a timestamp">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
@@ -23,13 +23,17 @@
 			<VarDeclaration Name="startDate" Type="DT" Comment="the start date used to calculate different timestamp types" InitialValue="DT#1970-01-01-00:00:00"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="ULINT" Comment="the new timestamp in nanoseconds, default Unix-Epoch"/>
+			<VarDeclaration Name="" Type="ULINT"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[FUNCTION TIMESTAMP_NS : ULINT
+		<ST><![CDATA[PACKAGE eclipse4diac::utils::timing;
+
+(* Creates by default a Unix-Epoch-Timestamp in nanoseconds. Use other start dates for other
+ * timestamp types. *)
+FUNCTION TIMESTAMP_NS : ULINT // the new timestamp in nanoseconds, default Unix-Epoch
 VAR_INPUT
-	startDate : DT := DT#1970-01-01-00:00:00;
+	startDate : DT := DT#1970-01-01-00:00:00; // the start date used to calculate different timestamp types
 END_VAR
 TIMESTAMP_NS := TIME_IN_NS_TO_ULINT(NOW() - startDate);
 END_FUNCTION


### PR DESCRIPTION
Standardize the package naming to "eclipse4diac::signalprocessing" for consistency with naming conventions. Added version information for tracking these changes to both FIELDBUS_PERCENT_TO_WORD and FIELDBUS_WORD_TO_PERCENT functions.

## Summary by Sourcery

Standardize metadata and naming for signal processing and timing function blocks.

Enhancements:
- Align FIELDBUS_PERCENT_TO_WORD and FIELDBUS_WORD_TO_PERCENT function metadata with the eclipse4diac::signalprocessing package naming convention.
- Update versioning information for affected signal processing and timing utility functions to track the namespace changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added 3.1 version entries across multiple function libraries.

* **Documentation**
  * Updated and clarified conversion comments, description text, and variable/event annotations; corrected minor typos.

* **Maintenance**
  * Standardized package qualifiers and normalized embedded Structured Text formatting; removed empty metadata attributes. All functional logic and interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->