### PR TITLE
Refactor and extend multiplexer functions within iec61131 library

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,17 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="lowest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[ALGORITHM REQ
+OUT := LOWER_BOUND(ARR, DIM);
+END_ALGORITHM
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,17 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="highest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[ALGORITHM REQ
+OUT := UPPER_BOUND(ARR, DIM);
+END_ALGORITHM
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_5.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_5.fbt
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_5" Comment="multiplexer">
+	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="4diac-ide" Version="1.0" Author="Gemini CLI" Date="2026-05-29" Remarks="created from F_MUX_4">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::selection">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="ANY_INT" Comment="Select one of n inputs"/>
+			<VarDeclaration Name="IN1" Type="ANY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Input value 2"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Input value 3"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Input value 4"/>
+			<VarDeclaration Name="IN5" Type="ANY" Comment="Input value 5"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_6.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_6.fbt
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_6" Comment="multiplexer">
+	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="4diac-ide" Version="1.0" Author="Gemini CLI" Date="2026-05-29" Remarks="created from F_MUX_4">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::selection">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="ANY_INT" Comment="Select one of n inputs"/>
+			<VarDeclaration Name="IN1" Type="ANY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Input value 2"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Input value 3"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Input value 4"/>
+			<VarDeclaration Name="IN5" Type="ANY" Comment="Input value 5"/>
+			<VarDeclaration Name="IN6" Type="ANY" Comment="Input value 6"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4, IN6 for K = 5"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_7.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_7.fbt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_7" Comment="multiplexer">
+	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="4diac-ide" Version="1.0" Author="Gemini CLI" Date="2026-05-29" Remarks="created from F_MUX_4">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::selection">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="ANY_INT" Comment="Select one of n inputs"/>
+			<VarDeclaration Name="IN1" Type="ANY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Input value 2"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Input value 3"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Input value 4"/>
+			<VarDeclaration Name="IN5" Type="ANY" Comment="Input value 5"/>
+			<VarDeclaration Name="IN6" Type="ANY" Comment="Input value 6"/>
+			<VarDeclaration Name="IN7" Type="ANY" Comment="Input value 7"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4, IN6 for K = 5, IN7 for K = 6"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_8.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_8.fbt
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_8" Comment="multiplexer">
+	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="4diac-ide" Version="1.0" Author="Gemini CLI" Date="2026-05-29" Remarks="created from F_MUX_4">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::selection">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="ANY_INT" Comment="Select one of n inputs"/>
+			<VarDeclaration Name="IN1" Type="ANY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Input value 2"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Input value 3"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Input value 4"/>
+			<VarDeclaration Name="IN5" Type="ANY" Comment="Input value 5"/>
+			<VarDeclaration Name="IN6" Type="ANY" Comment="Input value 6"/>
+			<VarDeclaration Name="IN7" Type="ANY" Comment="Input value 7"/>
+			<VarDeclaration Name="IN8" Type="ANY" Comment="Input value 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4, IN6 for K = 5, IN7 for K = 6, IN8 for K = 7"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_9.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_MUX_9.fbt
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_9" Comment="multiplexer">
+	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="4diac-ide" Version="1.0" Author="Gemini CLI" Date="2026-05-29" Remarks="created from F_MUX_4">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::selection">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="ANY_INT" Comment="Select one of n inputs"/>
+			<VarDeclaration Name="IN1" Type="ANY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Input value 2"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Input value 3"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Input value 4"/>
+			<VarDeclaration Name="IN5" Type="ANY" Comment="Input value 5"/>
+			<VarDeclaration Name="IN6" Type="ANY" Comment="Input value 6"/>
+			<VarDeclaration Name="IN7" Type="ANY" Comment="Input value 7"/>
+			<VarDeclaration Name="IN8" Type="ANY" Comment="Input value 8"/>
+			<VarDeclaration Name="IN9" Type="ANY" Comment="Input value 9"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4, IN6 for K = 5, IN7 for K = 6, IN8 for K = 7, IN9 for K = 8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Renamed F_LOWER_BOUND to F_MUX_5, F_MUX_6, F_MUX_7, added F_MUX_8 and F_MUX_9. Adjusted corresponding inputs, outputs, and type definitions. Moved array-bound functions to the 'arrays' directory for better organization.

## Summary by Sourcery

Refactor IEC 61131 type library selection functions to introduce dedicated multiplexer function blocks and reorganize array-bound utilities into a more appropriate directory.

New Features:
- Add new F_MUX_5 through F_MUX_9 selection function blocks in the IEC 61131 type library.

Enhancements:
- Relocate F_LOWER_BOUND and F_UPPER_BOUND function block definitions from the selection directory to the arrays directory for clearer separation of concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new multiplexer function blocks (F_MUX_5–F_MUX_9) for flexible selection from 5 to 9 input sources.

* **Bug Fixes**
  * Reorganized array bound functions to the arrays library category.
  * Added missing implementations for array bound functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->