### PR TITLE
Add minimum inter-disposal time feature to data latch (d) flip flop

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY.fbt
@@ -31,8 +31,8 @@
 			<ECState Name="SET" Comment="Initialization" x="1235" y="665">
 				<ECAction Algorithm="LATCH" Output="EO"/>
 			</ECState>
-			<ECTransition Source="SET" Destination="START" Condition="1" Comment="" x="946.67" y="1186.67"/>
-			<ECTransition Source="START" Destination="SET" Condition="CLK[NE(Q, D)]" Comment="" x="980" y="320"/>
+			<ECTransition Source="SET" Destination="SET" Condition="CLK[NE(Q, D)]" Comment="" x="1380" y="193.33"/>
+			<ECTransition Source="START" Destination="SET" Condition="CLK" Comment="" x="780" y="420"/>
 		</ECC>
 		<Algorithm Name="LATCH" Comment="new algorithm">
 			<ST><![CDATA[Q := D;]]></ST>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_TMIN.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_TMIN.fbt
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_TMIN" Comment="Data latch (d) flip flop, with a Minimum inter-disposal Time between EO">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-14" Remarks="Inital API">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Init Request">
+				<With Var="Tmin"/>
+			</Event>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Init Confirmation">
+			</Event>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of Q">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D" Type="ANY" Comment="Value to latch"/>
+			<VarDeclaration Name="Tmin" Type="TIME" Comment="Minimum inter-arrival time between EI events"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="ANY" Comment="Latched value"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_D_FF_ANY" Type="iec61499::events::E_D_FF_ANY" x="900" y="400">
+		</FB>
+		<FB Name="E_TMIN" Type="iec61499::events::E_TMIN" x="2100" y="1000">
+		</FB>
+		<EventConnections>
+			<Connection Source="CLK" Destination="E_D_FF_ANY.CLK" dx1="1606.67"/>
+			<Connection Source="INIT" Destination="E_TMIN.INIT" dx1="2253.33"/>
+			<Connection Source="E_TMIN.INITO" Destination="INITO" dx1="1166.67"/>
+			<Connection Source="E_TMIN.EO" Destination="EO" dx1="1773.33"/>
+			<Connection Source="E_D_FF_ANY.EO" Destination="E_TMIN.EI" dx1="220"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="E_D_FF_ANY.Q" Destination="Q" dx1="3080"/>
+			<Connection Source="D" Destination="E_D_FF_ANY.D" dx1="866.67"/>
+			<Connection Source="Tmin" Destination="E_TMIN.Tmin" dx1="566.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_TMIN.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_TMIN.fbt
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_TMIN" Comment="Data latch (d) flip flop, with a Minimum inter-disposal Time between EO">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-14" Remarks="Inital API">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Init Request">
+				<With Var="Tmin"/>
+			</Event>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Init Confirmation">
+			</Event>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of Q">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D" Type="BOOL" Comment="Value to latch"/>
+			<VarDeclaration Name="Tmin" Type="TIME" Comment="Minimum inter-arrival time between EI events"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Latched value"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="900" y="400">
+		</FB>
+		<FB Name="E_TMIN" Type="iec61499::events::E_TMIN" x="3500" y="1000">
+		</FB>
+		<EventConnections>
+			<Connection Source="CLK" Destination="E_D_FF.CLK" dx1="1606.67"/>
+			<Connection Source="INIT" Destination="E_TMIN.INIT" dx1="4966.67"/>
+			<Connection Source="E_TMIN.INITO" Destination="INITO" dx1="1800"/>
+			<Connection Source="E_D_FF.EO" Destination="E_TMIN.EI" dx1="573.33"/>
+			<Connection Source="E_TMIN.EO" Destination="EO" dx1="2280"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="E_D_FF.Q" Destination="Q" dx1="3080"/>
+			<Connection Source="D" Destination="E_D_FF.D" dx1="866.67"/>
+			<Connection Source="Tmin" Destination="E_TMIN.Tmin" dx1="433.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
@@ -18,7 +18,7 @@
       <Event Comment="Output, switched from EI when G=1" Name="EO1" Type="Event"/>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="Switch EI to EI0 when G=0, to EI1 when G=1 " Name="G" Type="BOOL"/>
+      <VarDeclaration Comment="Switch EI to EO0 when G=0, to EO1 when G=1 " Name="G" Type="BOOL"/>
     </InputVars>
     <OutputVars/>
   </InterfaceList>

--- a/data/typelibrary/events-3.0.0/typelib/E_TMIN.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_TMIN.fbt
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_TMIN" Comment="Forwards Events with a minimum inter-arrival time between EI events">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-14" Remarks="Initial API">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="Tmin"/>
+			</Event>
+			<Event Name="EI" Type="Event">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+			<Event Name="EO" Type="Event">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="Tmin" Type="TIME" Comment="Minimum inter-arrival time between EI events"/>
+		</InputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_REND" Type="iec61499::events::E_REND" x="900" y="400">
+		</FB>
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="2200" y="800">
+		</FB>
+		<EventConnections>
+			<Connection Source="E_DELAY.EO" Destination="E_REND.EI2" dx1="293.33" dx2="373.33" dy="520"/>
+			<Connection Source="E_REND.EO" Destination="E_DELAY.START" dx1="353.33"/>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="E_REND.EI2" dx1="2940"/>
+			<Connection Source="EI" Destination="E_REND.EI1" dx1="2086.67"/>
+			<Connection Source="E_REND.EO" Destination="EO" dx1="1333.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="Tmin" Destination="E_DELAY.DT" dx1="1440"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE_RETRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE_RETRIG.fbt
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_PULSE_RETRIG" Comment="standard timer function block (pulse) - retriggerable version">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_PULSE_RETRIG -- Impulse forming FB (Retriggerable) &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q. New REQ restarts the timer.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-04-19" Remarks="retriggerable version">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request (Restarts the timer)">
+				<With Var="PT"/>
+			</Event>
+			<Event Name="R" Type="Event" Comment="Reset">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Pulse time"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="-780" y="-573.33">
+		</FB>
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="373.33" y="-986.67">
+		</FB>
+		<EventConnections>
+			<Connection Source="REQ" Destination="E_DELAY.START" dx1="480"/>
+			<Connection Source="REQ" Destination="E_SR.S" dx1="1053.33"/>
+			<Connection Source="E_DELAY.EO" Destination="E_SR.R" dx1="253.33"/>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="1533.33"/>
+			<Connection Source="R" Destination="E_DELAY.STOP" dx1="366.67"/>
+			<Connection Source="R" Destination="E_SR.R" dx1="960"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="PT" Destination="E_DELAY.DT" dx1="266.67"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="2340"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/timers/E_TLIM.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_TLIM.fbt
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_TLIM" Comment="standard timer function block (time-limiting, timeout)">
+	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_TLIM -- Time-limiting timer FB  &#10;&#10;When IN goes TRUE, Q becomes TRUE and a timer starts.  &#10;If IN stays TRUE longer than PT, Q goes FALSE (timeout).  &#10;If IN goes FALSE before PT expires, Q goes FALSE immediately.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-08" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+				<With Var="PT"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BOOL" Comment="Input"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Process time"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_RF_TRIG" Type="iec61499::events::E_RF_TRIG" x="-1000" y="-1000">
+		</FB>
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="200" y="-600">
+		</FB>
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="1400" y="-1000">
+		</FB>
+		<EventConnections>
+			<Connection Source="REQ" Destination="E_RF_TRIG.EI" dx1="200"/>
+			<Connection Source="E_RF_TRIG.ER" Destination="E_DELAY.START" dx1="306.67"/>
+			<Connection Source="E_RF_TRIG.EF" Destination="E_DELAY.STOP" dx1="146.67"/>
+			<Connection Source="E_DELAY.EO" Destination="E_SR.R" dx1="266.67"/>
+			<Connection Source="E_RF_TRIG.EF" Destination="E_SR.R" dx1="846.67"/>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="1033.33"/>
+			<Connection Source="E_RF_TRIG.ER" Destination="E_SR.S" dx1="846.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN" Destination="E_RF_TRIG.QI" dx1="166.67"/>
+			<Connection Source="PT" Destination="E_DELAY.DT" dx1="80"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="1066.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/timers/E_TP_RETRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_TP_RETRIG.fbt
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_TP_RETRIG" Comment="standard timer function block (pulse) - retriggerable version">
+	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_TP_RETRIG -- Timer Pulse FB (Retriggerable) &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q on rising edge of IN. New REQ restarts the timer.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2026-04-19" Remarks="retriggerable version">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request (Restarts the timer)">
+				<With Var="IN"/>
+				<With Var="PT"/>
+			</Event>
+			<Event Name="R" Type="Event" Comment="Reset">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BOOL" Comment="Input"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Pulse time"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="353.33" y="-260">
+		</FB>
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="1506.67" y="-553.33">
+		</FB>
+		<FB Name="E_R_TRIG" Type="iec61499::events::E_R_TRIG" x="-1866.67" y="-933.33">
+		</FB>
+		<EventConnections>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="966.67"/>
+			<Connection Source="R" Destination="E_DELAY.STOP" dx1="226.67"/>
+			<Connection Source="R" Destination="E_SR.R" dx1="226.67"/>
+			<Connection Source="E_DELAY.EO" Destination="E_SR.R" dx1="266.67"/>
+			<Connection Source="REQ" Destination="E_R_TRIG.EI" dx1="1066.67"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_SR.S" dx1="1360"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_DELAY.START" dx1="780"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="PT" Destination="E_DELAY.DT" dx1="193.33"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="1000"/>
+			<Connection Source="IN" Destination="E_R_TRIG.QI" dx1="1066.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Implements an additional FBType `E_D_FF_ANY_TMIN` based on `E_D_FF_ANY` with an inter-disposal time constraint between events EO using a new FB `E_TMIN`. Extends functionality with event `INIT` and corresponding outputs to manage timing controls. Introduces new FBTypes `E_PULSE_RETRIG`, `E_TLIM`, and `E_TP_RETRIG` improving event handling capabilities with timing features.

## Summary by Sourcery

Add new event function blocks to support minimum inter-disposal timing constraints for data latch flip-flops and related timed event handling.

New Features:
- Introduce E_D_FF_ANY_TMIN and E_D_FF_TMIN flip-flop FB types with configurable minimum time between output events.
- Add E_TMIN function block to enforce inter-disposal time constraints on events.
- Add new retriggerable timer function blocks E_PULSE_RETRIG, E_TLIM, and E_TP_RETRIG to enhance timed event handling.
- Extend existing E_D_FF_ANY and E_SWITCH FB types with initialization and timing-related event capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new flip-flop variants with configurable minimum timing constraints for improved event handling
  * Added new timer function block types including retriggerable pulse generators and time limiters for event-driven applications
  * Extended control block library with improved timing control capabilities

* **Bug Fixes**
  * Refined flip-flop state transition control behavior for better timing precision

* **Documentation**
  * Clarified event demultiplexer control descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->