### PR TITLE
Enhance array utilities and add LWORD assembly/splitting functions

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/arrays/F_LEN_ARRAY.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/arrays/F_LEN_ARRAY.fbt
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="F_LEN_ARRAY" Comment="Service Interface Function Block Type">
-	<Identification Standard="61499-2" Classification="array function" Description="Copyright (c) 2026 Martin Melik Merkumians&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/">
+<FBType Name="F_LEN_ARRAY" Comment="Returns the length of the dimension of the given array">
+	<Identification Standard="61499-2" Classification="array function" Description="Copyright (c) 2026 Martin Melik Merkumians, Demmler Andreas Fahrzeugbau&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/">
 	</Identification>
+	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.1" Author="Franz Höpfinger" Date="2026-04-11" Remarks="make same as F_nn_BOUND">
+	</VersionInfo>
 	<VersionInfo Version="1.0" Author="Martin Melik Merkumians" Date="2026-03-25">
 	</VersionInfo>
-	<CompilerInfo packageName="utils::arrays">
+	<CompilerInfo packageName="eclipse4diac::utils::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -16,17 +18,27 @@
 		<EventOutputs>
 			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
 				<With Var="OUT"/>
-				<With Var="ARR"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
+			<VarDeclaration Name="ARR" Type="ANY_DERIVED" Comment="input array"/>
 			<VarDeclaration Name="DIM" Type="ANY_INT" Comment="Selects array dimension to get the length from, defaults to first dimension" InitialValue="DINT#1"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="Length of the selected array dimension"/>
 		</OutputVars>
-		<InOutVars>
-			<VarDeclaration Name="ARR" Type="ANY_DERIVED" Comment="Input array"/>
-		</InOutVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[ALGORITHM REQ
+OUT := ADD(SUB(UPPER_BOUND(ARR, DIM), LOWER_BOUND(ARR, DIM)), 1);
+END_ALGORITHM
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_BYTES.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_BYTES.fct
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="ASSEMBLE_LWORD_FROM_BYTES" Comment="this Function combines the 8 BYTES to a LWORD">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::assembling">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="BYTE_00"/>
+				<With Var="BYTE_01"/>
+				<With Var="BYTE_02"/>
+				<With Var="BYTE_03"/>
+				<With Var="BYTE_04"/>
+				<With Var="BYTE_05"/>
+				<With Var="BYTE_06"/>
+				<With Var="BYTE_07"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var=""/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="BYTE_00" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_01" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_02" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_03" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_04" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_05" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_06" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_07" Type="BYTE" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="" Type="LWORD" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function combines the 8 BYTES to a LWORD *)
+FUNCTION ASSEMBLE_LWORD_FROM_BYTES : LWORD
+
+VAR_INPUT
+	BYTE_00 : BYTE;
+	BYTE_01 : BYTE;
+	BYTE_02 : BYTE;
+	BYTE_03 : BYTE;
+	BYTE_04 : BYTE;
+	BYTE_05 : BYTE;
+	BYTE_06 : BYTE;
+	BYTE_07 : BYTE;
+END_VAR
+
+ASSEMBLE_LWORD_FROM_BYTES.%B0 := BYTE_00;
+ASSEMBLE_LWORD_FROM_BYTES.%B1 := BYTE_01;
+ASSEMBLE_LWORD_FROM_BYTES.%B2 := BYTE_02;
+ASSEMBLE_LWORD_FROM_BYTES.%B3 := BYTE_03;
+ASSEMBLE_LWORD_FROM_BYTES.%B4 := BYTE_04;
+ASSEMBLE_LWORD_FROM_BYTES.%B5 := BYTE_05;
+ASSEMBLE_LWORD_FROM_BYTES.%B6 := BYTE_06;
+ASSEMBLE_LWORD_FROM_BYTES.%B7 := BYTE_07;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>

--- a/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_DWORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_DWORDS.fct
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="ASSEMBLE_LWORD_FROM_DWORDS" Comment="this Function combines the 2 DWORDS to a LWORD">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::assembling">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="DWORD_00"/>
+				<With Var="DWORD_01"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var=""/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DWORD_00" Type="DWORD" Comment=""/>
+			<VarDeclaration Name="DWORD_01" Type="DWORD" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="" Type="LWORD" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function combines the 2 DWORDS to a LWORD *)
+FUNCTION ASSEMBLE_LWORD_FROM_DWORDS : LWORD
+
+VAR_INPUT
+	DWORD_00 : DWORD;
+	DWORD_01 : DWORD;
+END_VAR
+
+ASSEMBLE_LWORD_FROM_DWORDS.%D0 := DWORD_00;
+ASSEMBLE_LWORD_FROM_DWORDS.%D1 := DWORD_01;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>

--- a/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_WORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_LWORD_FROM_WORDS.fct
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="ASSEMBLE_LWORD_FROM_WORDS" Comment="this Function combines the 4 WORDS to a LWORD">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::assembling">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="WORD_00"/>
+				<With Var="WORD_01"/>
+				<With Var="WORD_02"/>
+				<With Var="WORD_03"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var=""/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="WORD_00" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_01" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_02" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_03" Type="WORD" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="" Type="LWORD" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function combines the 4 WORDS to a LWORD *)
+FUNCTION ASSEMBLE_LWORD_FROM_WORDS : LWORD
+
+VAR_INPUT
+	WORD_00 : WORD;
+	WORD_01 : WORD;
+	WORD_02 : WORD;
+	WORD_03 : WORD;
+END_VAR
+
+ASSEMBLE_LWORD_FROM_WORDS.%W0 := WORD_00;
+ASSEMBLE_LWORD_FROM_WORDS.%W1 := WORD_01;
+ASSEMBLE_LWORD_FROM_WORDS.%W2 := WORD_02;
+ASSEMBLE_LWORD_FROM_WORDS.%W3 := WORD_03;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>

--- a/data/typelibrary/utils-3.0.0/typelib/const/quarterconst.gcf
+++ b/data/typelibrary/utils-3.0.0/typelib/const/quarterconst.gcf
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<VersionInfo Version="1.0" Author="franz" Date="2024-02-22">
+	<VersionInfo Version="1.0" Author="Franz Höpfinger" Date="2024-02-22">
 	</VersionInfo>
 	<CompilerInfo packageName="eclipse4diac::utils::const">
 	</CompilerInfo>

--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_WORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_WORDS.fct
@@ -2,6 +2,8 @@
 <Function Name="SPLIT_DWORD_INTO_WORDS" Comment="this Function extracts the 2 WORD from a dword">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="3.1" Author="Franz Höpfinger" Date="2026-05-16" Remarks="Fix Bug in word 1">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik" Version="1.1" Author="Moritz Ortmeier" Date="2024-07-24" Remarks="rename Function and change Output Variables">
@@ -44,7 +46,7 @@ VAR_OUTPUT
 END_VAR
 
 WORD_00 := IN.%W0;
-WORD_01 := IN.%X1;
+WORD_01 := IN.%W1;
 
 END_FUNCTION
 ]]></ST>

--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_BYTES.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_BYTES.fct
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="SPLIT_LWORD_INTO_BYTES" Comment="this Function extracts the 8 BYTES from a lword">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::splitting">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="BYTE_00"/>
+				<With Var="BYTE_01"/>
+				<With Var="BYTE_02"/>
+				<With Var="BYTE_03"/>
+				<With Var="BYTE_04"/>
+				<With Var="BYTE_05"/>
+				<With Var="BYTE_06"/>
+				<With Var="BYTE_07"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="LWORD" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="BYTE_00" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_01" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_02" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_03" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_04" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_05" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_06" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_07" Type="BYTE" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function extracts the 8 BYTES from a lword *)
+FUNCTION SPLIT_LWORD_INTO_BYTES
+
+VAR_INPUT
+	IN : LWORD;
+END_VAR
+
+VAR_OUTPUT
+	BYTE_00 : BYTE;
+	BYTE_01 : BYTE;
+	BYTE_02 : BYTE;
+	BYTE_03 : BYTE;
+	BYTE_04 : BYTE;
+	BYTE_05 : BYTE;
+	BYTE_06 : BYTE;
+	BYTE_07 : BYTE;
+END_VAR
+
+BYTE_00 := IN.%B0;
+BYTE_01 := IN.%B1;
+BYTE_02 := IN.%B2;
+BYTE_03 := IN.%B3;
+BYTE_04 := IN.%B4;
+BYTE_05 := IN.%B5;
+BYTE_06 := IN.%B6;
+BYTE_07 := IN.%B7;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>

--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_DWORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_DWORDS.fct
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="SPLIT_LWORD_INTO_DWORDS" Comment="this Function extracts the 2 DWORDS from a lword">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::splitting">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="DWORD_00"/>
+				<With Var="DWORD_01"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="LWORD" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="DWORD_00" Type="DWORD" Comment=""/>
+			<VarDeclaration Name="DWORD_01" Type="DWORD" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function extracts the 2 DWORDS from a lword *)
+FUNCTION SPLIT_LWORD_INTO_DWORDS
+
+VAR_INPUT
+	IN : LWORD;
+END_VAR
+
+VAR_OUTPUT
+	DWORD_00 : DWORD;
+	DWORD_01 : DWORD;
+END_VAR
+
+DWORD_00 := IN.%D0;
+DWORD_01 := IN.%D1;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>

--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_WORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_LWORD_INTO_WORDS.fct
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="SPLIT_LWORD_INTO_WORDS" Comment="this Function extracts the 4 WORDS from a lword">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2026-05-16" Remarks="initial Implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::splitting">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="WORD_00"/>
+				<With Var="WORD_01"/>
+				<With Var="WORD_02"/>
+				<With Var="WORD_03"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="LWORD" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="WORD_00" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_01" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_02" Type="WORD" Comment=""/>
+			<VarDeclaration Name="WORD_03" Type="WORD" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function extracts the 4 WORDS from a lword *)
+FUNCTION SPLIT_LWORD_INTO_WORDS
+
+VAR_INPUT
+	IN : LWORD;
+END_VAR
+
+VAR_OUTPUT
+	WORD_00 : WORD;
+	WORD_01 : WORD;
+	WORD_02 : WORD;
+	WORD_03 : WORD;
+END_VAR
+
+WORD_00 := IN.%W0;
+WORD_01 := IN.%W1;
+WORD_02 := IN.%W2;
+WORD_03 := IN.%W3;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>


### PR DESCRIPTION
Refactor F_LEN_ARRAY to return array dimension length and update package structure. Introduce functions for assembling and splitting LWORD into bytes, DWORDS, and WORDS. Fix bug in SPLIT_DWORD_INTO_WORDS for correct word extraction.

## Summary by Sourcery

Enhance array utilities and add LWORD data assembly/splitting helpers.

New Features:
- Add functions to assemble LWORD values from bytes, WORDs, and DWORDs.
- Add functions to split LWORD values into bytes, WORDs, and DWORDs.

Bug Fixes:
- Correct SPLIT_DWORD_INTO_WORDS to extract words from a DWORD correctly.

Enhancements:
- Refine F_LEN_ARRAY to return the array dimension length and adjust its placement within the package structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data assembly utilities: `ASSEMBLE_LWORD_FROM_BYTES`, `ASSEMBLE_LWORD_FROM_DWORDS`, and `ASSEMBLE_LWORD_FROM_WORDS`.
  * Added data splitting utilities: `SPLIT_LWORD_INTO_BYTES`, `SPLIT_LWORD_INTO_DWORDS`, and `SPLIT_LWORD_INTO_WORDS`.
  * Enhanced `F_LEN_ARRAY` function block with improved interface and explicit implementation.

* **Bug Fixes**
  * Fixed `SPLIT_DWORD_INTO_WORDS` word extraction logic.

* **Chores**
  * Updated metadata for utility library functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->