### PR TITLE
Add new CLIENT and SERVER block types for net-3.0.0 library

### DIFF
--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_1.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_1.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_0_1" Comment="Connect to a SERVER_1 Block">
+<FBType Name="CLIENT_0_1" Comment="Connect to a SERVER_1_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-19-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_10.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_10.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_10" Comment="Connect to a SERVER_10_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,35 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+				<With Var="RD_10"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+			<VarDeclaration Name="RD_10" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_2.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_2.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_2" Comment="Connect to a SERVER_2_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,19 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_3.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_3.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_3" Comment="Connect to a SERVER_3_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,21 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_4.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_4.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_4" Comment="Connect to a SERVER_4_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,23 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_5.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_5.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_5" Comment="Connect to a SERVER_5_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,25 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_6.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_6.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_6" Comment="Connect to a SERVER_6_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,27 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_7.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_7.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_7" Comment="Connect to a SERVER_7_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,29 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_8.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_8.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_8" Comment="Connect to a SERVER_8_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,31 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_9.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_9.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_0_9" Comment="Connect to a SERVER_9_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
 	</VersionInfo>
@@ -14,7 +14,6 @@
 			</Event>
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +24,33 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_10.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_10.fbt
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_10" Comment="Connect to a SERVER_10 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+				<With Var="SD_10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+				<With Var="RD_10"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+			<VarDeclaration Name="SD_10" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+			<VarDeclaration Name="RD_10" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_10_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_10_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_10_0" Comment="Connect to a SERVER_0_10 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,15 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+				<With Var="SD_10"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +40,15 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+			<VarDeclaration Name="SD_10" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_2.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_2.fbt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_2" Comment="Connect to a SERVER_2 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
@@ -15,6 +17,7 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +28,21 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_2_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_2_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_2_0" Comment="Connect to a SERVER_0_2 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,7 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +32,7 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_3.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_3.fbt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_3" Comment="Connect to a SERVER_3 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
@@ -15,6 +17,8 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +29,24 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_3_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_3_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_3_0" Comment="Connect to a SERVER_0_3 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,8 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +33,8 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_3_2.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_3_2.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_3_2" Comment="Client with 3 inputs and 2 outputs, needed for HTTP">
+<FBType Name="CLIENT_3_2" Comment="Connect to a SERVER_2_3 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2024 Monika Wenger&#10;  &#10;This program and the accompanying materials are made &#10;available under the terms of the Eclipse Public License 2.0 &#10;which is available at https://www.eclipse.org/legal/epl-2.0/ &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0" Author="Franz Höpfinger" Date="2025-04-14" Remarks=" Made Version 3.0.0 inspired by Work from Patrick Aigner">

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_4.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_4.fbt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_4" Comment="Connect to a SERVER_4 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
@@ -15,6 +17,9 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +30,27 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_4_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_4_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_4_0" Comment="Connect to a SERVER_0_4 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,9 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +34,9 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_5.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_5.fbt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
-	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+<FBType Name="CLIENT_5" Comment="Connect to a SERVER_5 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
@@ -15,6 +17,10 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,16 +31,30 @@
 			<Event Name="CNF" Type="Event" Comment="New data available from Server">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_5_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_5_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_5_0" Comment="Connect to a SERVER_0_5 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,10 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +35,10 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_6.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_6.fbt
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_6" Comment="Connect to a SERVER_6 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_6_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_6_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_6_0" Comment="Connect to a SERVER_0_6 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,11 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +36,11 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_7.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_7.fbt
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_7" Comment="Connect to a SERVER_7 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_7_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_7_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_7_0" Comment="Connect to a SERVER_0_7 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,12 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +37,12 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_8.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_8.fbt
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_8" Comment="Connect to a SERVER_8 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_8_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_8_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_8_0" Comment="Connect to a SERVER_0_8 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,13 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +38,13 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_9.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_9.fbt
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_9" Comment="Connect to a SERVER_9 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_9_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_9_0.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="CLIENT_9_0" Comment="Connect to a SERVER_0_9 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
@@ -15,6 +15,14 @@
 			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,6 +39,14 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_1.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_1.fbt
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_1" Comment="Connect to a CLIENT_1_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_1">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_10.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_10.fbt
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_0_10" Comment="Connect to a CLIENT_10_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_10">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+				<With Var="RD_10"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+			<VarDeclaration Name="RD_10" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_2.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_2.fbt
@@ -1,42 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_2" Comment="Connect to a CLIENT_2_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_2">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_3.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_3.fbt
@@ -1,42 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_3" Comment="Connect to a CLIENT_3_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_3">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_4.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_4.fbt
@@ -1,42 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_4" Comment="Connect to a CLIENT_4_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_4">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_5.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_5.fbt
@@ -1,42 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_5" Comment="Connect to a CLIENT_5_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_5">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_6.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_6.fbt
@@ -1,42 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_6" Comment="Connect to a CLIENT_6_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_6">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_7.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_7.fbt
@@ -1,42 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_0_7" Comment="Connect to a CLIENT_7_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_7">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
-				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_8.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_8.fbt
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_0_8" Comment="Connect to a CLIENT_8_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_8">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0_9.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0_9.fbt
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_0_9" Comment="Connect to a CLIENT_9_0 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_9">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_10.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_10.fbt
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_10" Comment="Connect to a CLIENT_10 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+				<With Var="SD_10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+				<With Var="RD_10"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+			<VarDeclaration Name="SD_10" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+			<VarDeclaration Name="RD_10" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_10_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_10_0.fbt
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_10_0" Comment="Connect to a CLIENT_0_10 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_10">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+				<With Var="SD_10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+			<VarDeclaration Name="SD_10" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_1_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_1_0.fbt
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_1_0" Comment="Connect to a CLIENT_0_1 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_1">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -37,6 +37,6 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_2.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_2.fbt
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_2" Comment="Connect to a CLIENT_2 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_2_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_2_0.fbt
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_2_0" Comment="Connect to a CLIENT_0_2 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_2">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +32,13 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_2_3.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_2_3.fbt
@@ -1,42 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_2_3" Comment="Connect to a CLIENT_3_2 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_3">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
-			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Response code from the server"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment="Body from the server's response"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY" Comment="Token for authentication at the server"/>
+			<VarDeclaration Name="RD_2" Type="ANY" Comment="Parameters for the message"/>
+			<VarDeclaration Name="RD_3" Type="ANY" Comment="Body of the message"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_3.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_3.fbt
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_3" Comment="Connect to a CLIENT_3 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_3_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_3_0.fbt
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_3_0" Comment="Connect to a CLIENT_0_3 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_3">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +33,14 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_4.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_4.fbt
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_4" Comment="Connect to a CLIENT_4 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_4_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_4_0.fbt
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_4_0" Comment="Connect to a CLIENT_0_4 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_4">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +34,15 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_5.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_5.fbt
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_5" Comment="Connect to a CLIENT_5 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_5_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_5_0.fbt
@@ -1,28 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_5_0" Comment="Connect to a CLIENT_0_5 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_5">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +35,16 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_6.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_6.fbt
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_6" Comment="Connect to a CLIENT_6 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_6_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_6_0.fbt
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_6_0" Comment="Connect to a CLIENT_0_6 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_6">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +36,17 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_7.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_7.fbt
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_7" Comment="Connect to a CLIENT_7 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_7_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_7_0.fbt
@@ -1,28 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_7_0" Comment="Connect to a CLIENT_0_7 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_7">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +37,18 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_8.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_8.fbt
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_8" Comment="Connect to a CLIENT_8 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_8_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_8_0.fbt
@@ -1,28 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_8_0" Comment="Connect to a CLIENT_0_8 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_8">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +38,19 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_9.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_9.fbt
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SERVER_9" Comment="Connect to a CLIENT_9 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-10-25" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+				<With Var="RD_2"/>
+				<With Var="RD_3"/>
+				<With Var="RD_4"/>
+				<With Var="RD_5"/>
+				<With Var="RD_6"/>
+				<With Var="RD_7"/>
+				<With Var="RD_8"/>
+				<With Var="RD_9"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+			<VarDeclaration Name="RD_2" Type="ANY"/>
+			<VarDeclaration Name="RD_3" Type="ANY"/>
+			<VarDeclaration Name="RD_4" Type="ANY"/>
+			<VarDeclaration Name="RD_5" Type="ANY"/>
+			<VarDeclaration Name="RD_6" Type="ANY"/>
+			<VarDeclaration Name="RD_7" Type="ANY"/>
+			<VarDeclaration Name="RD_8" Type="ANY"/>
+			<VarDeclaration Name="RD_9" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_9_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_9_0.fbt
@@ -1,28 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_0_1 Block">
+<FBType Name="SERVER_9_0" Comment="Connect to a CLIENT_0_9 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
 	</Identification>
-	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from CLIENT_1">
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-09-26" Remarks="Created from SERVER_9">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+			<Event Name="INIT" Type="EInit" Comment="Enable Server for a Client connection (QI = TRUE) / Close Server (QI = FALSE) ">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
-			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+			<Event Name="RSP" Type="Event" Comment="Send data to Client">
 				<With Var="QI"/>
 				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+			<Event Name="INITO" Type="EInit" Comment="Ready for Client Connection (QI = TRUE) / Closed  (QI = FALSE)">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
-			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+			<Event Name="IND" Type="Event" Comment="New data available from Client">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
@@ -31,12 +39,20 @@
 			<VarDeclaration Name="QI" Type="BOOL"/>
 			<VarDeclaration Name="ID" Type="WSTRING"/>
 			<VarDeclaration Name="SD_1" Type="ANY"/>
+			<VarDeclaration Name="SD_2" Type="ANY"/>
+			<VarDeclaration Name="SD_3" Type="ANY"/>
+			<VarDeclaration Name="SD_4" Type="ANY"/>
+			<VarDeclaration Name="SD_5" Type="ANY"/>
+			<VarDeclaration Name="SD_6" Type="ANY"/>
+			<VarDeclaration Name="SD_7" Type="ANY"/>
+			<VarDeclaration Name="SD_8" Type="ANY"/>
+			<VarDeclaration Name="SD_9" Type="ANY"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_SERVER'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION
Introduces CLIENT_0_10 to CLIENT_9 and SERVER_10 to SERVER_9 block types in the net-3.0.0 type library. These blocks facilitate connections between CLIENT and SERVER pairs with varying data transfer capabilities.

## Summary by Sourcery

Extend the net-3.0.0 type library with additional CLIENT and SERVER block variants to cover more connection and data transfer configurations.

New Features:
- Add CLIENT_0_2 through CLIENT_0_10 block types and corresponding CLIENT_2 through CLIENT_10 variants to support a wider range of client connection patterns.
- Add SERVER_0_2, SERVER_0_10, and SERVER_2 through SERVER_10 block types to complement the new client variants for server-side connections.

Enhancements:
- Adjust existing CLIENT_0_1 and CLIENT_1_0 block definitions to align with the expanded set of CLIENT/SERVER block types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many new CLIENT and SERVER function-block types (paired variants, including 0_x / x_0) covering 1–10 channel configurations.
  * Standardized event/data ports across all new blocks for consistent connect/request/response behavior.
  * Ready-to-use preconfigured client–server blocks (single- and multi-channel) to speed building of networked applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->