### PR TITLE
Enhance DualHysteresis logic with improved hysteresis handling

### DIFF
--- a/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis">
+<FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis (Switch-on = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)), Switch-off = MI +/- ABS(DEAD))">
 	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -32,9 +32,9 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier"/>
-			<VarDeclaration Name="MI" Type="REAL" Comment="MID Setting can e.g. be 0.5 meaning 50%" InitialValue="0.5"/>
-			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MID can be e.g. 0.1 meaning 10%" InitialValue="0.1"/>
-			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis can be 0.1 meaning 10%" InitialValue="0.1"/>
+			<VarDeclaration Name="MI" Type="REAL" Comment="Center point (e.g. 0.5 for 50%)" InitialValue="0.5"/>
+			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MI (Switch-off points = MI +/- ABS(DEAD))" InitialValue="0.1"/>
+			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis value (Switch-on points = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)))" InitialValue="0.1"/>
 			<VarDeclaration Name="INPUT" Type="REAL" Comment="Value"/>
 		</InputVars>
 		<OutputVars>
@@ -65,11 +65,11 @@
 			<ECTransition Source="START" Destination="Init" Condition="INIT[TRUE = QI]" Comment="" x="1206.67" y="2260"/>
 			<ECTransition Source="Init" Destination="Neutral" Condition="REQ" Comment="" x="2026.67" y="2313.33"/>
 			<ECTransition Source="Neutral" Destination="DeInit" Condition="INIT[FALSE = QI]" Comment="" x="2053.33" y="2680"/>
-			<ECTransition Source="Neutral" Destination="UP" Condition="REQ[INPUT &gt;= MI + DEAD + HYSTERESIS]" Comment="" x="5040" y="1173.33"/>
+			<ECTransition Source="Neutral" Destination="UP" Condition="REQ[INPUT &gt;= MI + ABS(DEAD) + ABS(HYSTERESIS)]" Comment="Switch-on UP (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
-			<ECTransition Source="Neutral" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - DEAD - HYSTERESIS]" Comment="" x="5513.33" y="3013.33"/>
-			<ECTransition Source="DOWN" Destination="Neutral" Condition="REQ[INPUT &gt; MI - DEAD]" Comment="" x="5173.33" y="3480"/>
-			<ECTransition Source="UP" Destination="Neutral" Condition="REQ[INPUT &lt; MI + DEAD]" Comment="" x="5173.33" y="2026.67"/>
+			<ECTransition Source="Neutral" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - ABS(DEAD) - ABS(HYSTERESIS)]" Comment="Switch-on DOWN (inclusive)" x="5513.33" y="3013.33"/>
+			<ECTransition Source="DOWN" Destination="Neutral" Condition="REQ[INPUT &gt; MI - ABS(DEAD)]" Comment="Switch-off DOWN (strict)" x="5173.33" y="3480"/>
+			<ECTransition Source="UP" Destination="Neutral" Condition="REQ[INPUT &lt; MI + ABS(DEAD)]" Comment="Switch-off UP (strict)" x="5173.33" y="2026.67"/>
 		</ECC>
 		<Algorithm Name="initialize">
 			<ST><![CDATA[ALGORITHM initialize


### PR DESCRIPTION
Adjust calculations for UP and DOWN state transitions by ensuring DEAD and HYSTERESIS values are treated as absolute. Update comments and logic to clarify switch-on and switch-off points.

https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac_training1/pull/67

## Summary by Sourcery

Enhancements:
- Clarify and adjust DualHysteresis UP and DOWN transition logic to treat DEAD and HYSTERESIS as absolute thresholds and better document switch-on/off points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected switching thresholds and transition logic so switch-on uses MI ± (|DEAD| + |HYSTERESIS|) and switch-off uses MI ± |DEAD| for more reliable hysteresis behavior.

* **Changes**
  * Improved DualHysteresis parameter documentation to clearly describe MI, DEAD, and HYSTERESIS semantics (no initial values changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->