### PR TITLE
Add algorithms for F_LOWER_BOUND and F_UPPER_BOUND as Simple FB

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,15 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="lowest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[
+OUT := LOWER_BOUND(ARR, DIM);
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,15 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="highest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[
+OUT := UPPER_BOUND(ARR, DIM);
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION
Reclassify F_LOWER_BOUND and F_UPPER_BOUND into arrays package

## Summary by Sourcery

Move F_LOWER_BOUND and F_UPPER_BOUND function block type definitions from the selection package to the arrays package to better reflect their purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the exported classification for array boundary functions so they are registered under the correct arrays category.
* **Bug Fixes**
  * Added runtime implementations for lower- and upper-bound operations, enabling these functions to execute properly and return computed `OUT` values from `ARR` and `DIM`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->