### PR TITLE
Correct variable comment to match event output behavior

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
@@ -18,7 +18,7 @@
       <Event Comment="Output, switched from EI when G=1" Name="EO1" Type="Event"/>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="Switch EI to EI0 when G=0, to EI1 when G=1 " Name="G" Type="BOOL"/>
+      <VarDeclaration Comment="Switch EI to EO0 when G=0, to EO1 when G=1 " Name="G" Type="BOOL"/>
     </InputVars>
     <OutputVars/>
   </InterfaceList>


### PR DESCRIPTION
Updates the comment for variable "G" to accurately reflect the switching behavior of event outputs in the interface definition.

fixes: https://github.com/eclipse-4diac/4diac-ide/issues/2509

## Summary by Sourcery

Documentation:
- Clarify the description of variable G in the E_SWITCH interface to match the actual event output switching behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the E_SWITCH module's interface documentation to accurately describe how the G input variable controls switching behavior between outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->