### PR TITLE
fix: Correct the order of adapter list creation in interface export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractBlockTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractBlockTypeExporter.java
@@ -79,8 +79,8 @@ public abstract class AbstractBlockTypeExporter extends AbstractTypeExporter {
 		addEventList(interfaceList.getEventOutputs(), getEventOutputsElementName());
 		addVarList(interfaceList.getInputVars(), LibraryElementTags.INPUT_VARS_ELEMENT);
 		addVarList(interfaceList.getOutputVars(), LibraryElementTags.OUTPUT_VARS_ELEMENT);
-		createAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT);
 		createAdapterList(interfaceList.getSockets(), LibraryElementTags.SOCKETS_ELEMENT);
+		createAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT);
 		addVarList(interfaceList.getInOutVars(), LibraryElementTags.INOUT_VARS_ELEMENT);
 		addEndElement();
 	}


### PR DESCRIPTION
Adjust the order of 'createAdapterList' method calls to maintain consistency with the expected sequence for exporting interface lists.

solves https://github.com/eclipse-4diac/4diac-ide/issues/2634

## Summary by Sourcery

Bug Fixes:
- Fix the interface export so that sockets are serialized before plugs, aligning with the expected adapter order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the order of exported adapter-related lists so sockets are written before plugs.
  * This improves consistency in generated XML output and may prevent issues when consuming exported block types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->