### PR TITLE
Refactor: Adjust order of XML entry methods in SystemExporter

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
@@ -106,8 +106,8 @@ public class SystemExporter extends AbstractTypeExporter {
 		final SystemConfiguration systemConfiguration = getType().getSystemConfiguration();
 		if (null != systemConfiguration) {
 			addDevices(systemConfiguration.getDevices());
-			addSegment(systemConfiguration.getSegments());
 			addMapping();
+			addSegment(systemConfiguration.getSegments());
 			addLink(systemConfiguration.getLinks());
 		}
 	}


### PR DESCRIPTION
Reorders the call to addSegment to be immediately after addDevices, ensuring a consistent logical sequence within createTypeSpecificXMLEntries. This change may help avoid potential issues arising from the previous method sequence.

## Summary by Sourcery

Enhancements:
- Adjust the sequence of XML entry creation in SystemExporter to align segments with mappings and links in a more logical order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency of exported system configuration data.
  * Exported output now follows a more reliable ordering, which may help prevent issues when files are re-imported or processed by other tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->